### PR TITLE
Fix paths in manifests and release script

### DIFF
--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -62,12 +62,12 @@ spec:
         - name: METRICS_DOMAIN
           value: knative.dev/sources
         - name: GL_RA_IMAGE
-          value: ko://knative.dev/eventing-contrib/gitlab/cmd/receive_adapter
+          value: ko://knative.dev/eventing-gitlab/cmd/receive_adapter
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ko://knative.dev/eventing-contrib/gitlab/cmd/controller
+        image: ko://knative.dev/eventing-gitlab/cmd/controller
         imagePullPolicy: Always
         resources:
           limits:

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -64,7 +64,7 @@ spec:
       containers:
       - name: gitlab-webhook
         terminationMessagePolicy: FallbackToLogsOnError
-        image: ko://knative.dev/eventing-contrib/gitlab/cmd/webhook
+        image: ko://knative.dev/eventing-gitlab/cmd/webhook
         env:
           - name: SYSTEM_NAMESPACE
             valueFrom:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -24,7 +24,7 @@ export GO111MODULE=on
 # Yaml files to generate, and the source config dir for them.
 declare -A COMPONENTS
 COMPONENTS=(
-  ["gitlab.yaml"]="gitlab/config"
+  ["gitlab.yaml"]="config"
 )
 readonly COMPONENTS
 


### PR DESCRIPTION
Fixes #2

## Proposed Changes

- Update paths of Go packages for `ko` in manifests under `config/`
- Remove a prefix carried from the old contrib repo in the release script