### PR TITLE
Set proper type and source attributes on emitted CloudEvents

### DIFF
--- a/config/300-gitlabsource.yaml
+++ b/config/300-gitlabsource.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -23,19 +22,46 @@ metadata:
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
   annotations:
-    # TODO add schemas and descriptions
+    # Webhook event types as documented at https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#events.
+    # NOTE(antoineco): GitLab doesn't currently provide schemas for those events (gitlab-org/gitlab#208924)
     registry.knative.dev/eventTypes: |
       [
-        { "type": "dev.knative.sources.gitlabsource.push_events" },
-        { "type": "dev.knative.sources.gitlabsource.push_events_branch_filter" },
-        { "type": "dev.knative.sources.gitlabsource.issues_events" },
-        { "type": "dev.knative.sources.gitlabsource.confidential_issues_events" },
-        { "type": "dev.knative.sources.gitlabsource.merge_requests_events" },
-        { "type": "dev.knative.sources.gitlabsource.tag_push_events" },
-        { "type": "dev.knative.sources.gitlabsource.note_events" },
-        { "type": "dev.knative.sources.gitlabsource.job_events" },
-        { "type": "dev.knative.sources.gitlabsource.pipeline_events" },
-        { "type": "dev.knative.sources.gitlabsource.wiki_page_events" }
+        {
+          "type": "dev.knative.sources.gitlab.build",
+          "description": "Triggered on status change of a job."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.deployment",
+          "description": "Triggered when a deployment starts, succeeds, fails, or is cancelled."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.issue",
+          "description": "Triggered when a new issue is created or an existing issue was updated/closed/reopened."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.merge_request",
+          "description": "Triggered when a merge request is created/updated/merged/closed or a commit is added in the source branch."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.note",
+          "description": "Triggered when a new comment is made on commits, merge requests, issues, and code snippets."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.pipeline",
+          "description": "Triggered on status change of Pipeline."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.push",
+          "description": "Triggered when you push to the repository except when pushing tags."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.tag_push",
+          "description": "Triggered when you create (or delete) tags to the repository."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.wiki_page",
+          "description": "Triggered when a wiki page is created, updated or deleted."
+        }
       ]
 spec:
   group: sources.knative.dev
@@ -96,8 +122,8 @@ spec:
                         a valid secret key.
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      # TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                     optional:
                       description: Specify whether the Secret or its key must be defined
@@ -107,19 +133,21 @@ spec:
                   type: object
               type: object
             eventTypes:
-              description: EventType is the type of event to receive from Gitlab.
-                These correspond to supported events to the add project hook https://docs.gitlab.com/ee/api/projects.html#add-project-hook
+              description: List of webhooks to enable on the selected GitLab
+                project. Those correspond to the attributes enumerated at
+                https://docs.gitlab.com/ee/api/projects.html#add-project-hook
               items:
                 enum:
-                - push_events
-                - push_events_branch_filter
-                - issues_events
                 - confidential_issues_events
-                - merge_requests_events
-                - tag_push_events
-                - note_events
+                - confidential_note_events
+                - deployment_events
+                - issues_events
                 - job_events
+                - merge_requests_events
+                - note_events
                 - pipeline_events
+                - push_events
+                - tag_push_events
                 - wiki_page_events
                 type: string
               minItems: 1

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -68,7 +68,6 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: ko://knative.dev/eventing-gitlab/cmd/controller
-        imagePullPolicy: Always
         resources:
           limits:
             cpu: 100m

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/cloudevents/sdk-go/v2 v2.2.0
 	github.com/google/go-cmp v0.5.2
-	github.com/google/uuid v1.1.2
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/stretchr/testify v1.6.0
 	github.com/xanzy/go-gitlab v0.39.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.2
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/stretchr/testify v1.6.0 // indirect
+	github.com/stretchr/testify v1.6.0
 	github.com/xanzy/go-gitlab v0.39.0
 	go.uber.org/zap v1.16.0
 	gopkg.in/go-playground/webhooks.v5 v5.15.0

--- a/pkg/adapter/receive_adapter.go
+++ b/pkg/adapter/receive_adapter.go
@@ -104,13 +104,13 @@ func (ra *gitLabReceiveAdapter) start(stopCh <-chan struct{}) error {
 		gracefulShutdown(server, ra.logger, stopCh)
 	}()
 
-	ra.logger.Infof("Server is ready to handle requests at %s", server.Addr)
+	ra.logger.Info("Server is ready to handle requests at ", server.Addr)
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("could not listen on %s: %v", server.Addr, err)
 	}
 
 	wg.Wait()
-	ra.logger.Infof("Server stopped")
+	ra.logger.Info("Server stopped")
 	return nil
 }
 
@@ -124,7 +124,7 @@ func gracefulShutdown(server *http.Server, logger *zap.SugaredLogger, stopCh <-c
 
 	server.SetKeepAlivesEnabled(false)
 	if err := server.Shutdown(ctx); err != nil {
-		logger.Fatalf("Could not gracefully shutdown the server: %v", err)
+		logger.Fatal("Could not gracefully shutdown the server: ", err)
 	}
 }
 
@@ -143,20 +143,20 @@ func (ra *gitLabReceiveAdapter) newRouter(hook *gitlab.Webhook) *http.ServeMux {
 			gitlab.BuildEvents,
 		)
 		if err != nil {
-			ra.logger.Errorf("Hook parser error: %v", err)
+			ra.logger.Error("Hook parser error: ", err)
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(err.Error()))
 			return
 		}
 
 		if err := ra.handleEvent(payload, r.Header); err != nil {
-			ra.logger.Errorf("Event handler error: %v", err)
+			ra.logger.Error("Event handler error: ", err)
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(err.Error()))
 			return
 		}
 
-		ra.logger.Debug("event processed")
+		ra.logger.Debug("Event processed")
 		w.WriteHeader(http.StatusAccepted)
 	})
 

--- a/pkg/apis/sources/v1alpha1/gitlabsource_lifecyle.go
+++ b/pkg/apis/sources/v1alpha1/gitlabsource_lifecyle.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import "sort"
+
+// String prepended to GitLab event types to make them fully-qualified.
+const eventPrefixGitLab = "dev.knative.sources.gitlab."
+
+// Types of events emitted by a GitLabSource.
+// The chosen format and case matches the "object_kind" attribute contained in
+// payloads sent by GitLab's webhooks.
+// https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#events
+const (
+	GitLabEventTypeBuild        = "build"
+	GitLabEventTypeDeployment   = "deployment"
+	GitLabEventTypeIssue        = "issue"
+	GitLabEventTypeMergeRequest = "merge_request"
+	GitLabEventTypeNote         = "note"
+	GitLabEventTypePipeline     = "pipeline"
+	GitLabEventTypePush         = "push"
+	GitLabEventTypeTagPush      = "tag_push"
+	GitLabEventTypeWikiPage     = "wiki_page"
+)
+
+// Types of webhooks that can be enabled on a GitLab project.
+// https://docs.gitlab.com/ee/api/projects.html#add-project-hook
+const (
+	GitLabWebhookConfidentialIssues = "confidential_issues_events"
+	GitLabWebhookConfidentialNote   = "confidential_note_events"
+	GitLabWebhookDeployment         = "deployment_events"
+	GitLabWebhookIssues             = "issues_events"
+	GitLabWebhookJob                = "job_events"
+	GitLabWebhookMergeRequests      = "merge_requests_events"
+	GitLabWebhookNote               = "note_events"
+	GitLabWebhookPipeline           = "pipeline_events"
+	GitLabWebhookPush               = "push_events"
+	GitLabWebhookTagPush            = "tag_push_events"
+	GitLabWebhookWikiPage           = "wiki_page_events"
+)
+
+// GitLabEventType returns a GitLab event type in a format suitable for usage
+// as a CloudEvent type attribute.
+func GitLabEventType(eventType string) string {
+	return eventPrefixGitLab + eventType
+}
+
+// EventTypes returns the types of events emitted by the source, sorted in
+// increasing lexical order.
+func (s *GitLabSource) EventTypes() []string {
+	// Some webhooks emit the same event type, so we use a map as an
+	// intermediate store to avoid duplicates in the returned slice.
+	uniqueTypes := make(map[string]struct{}, len(s.Spec.EventTypes))
+
+	for _, hook := range s.Spec.EventTypes {
+		uniqueTypes[eventTypeForWebhook(hook)] = struct{}{}
+	}
+
+	types := make([]string, 0, len(uniqueTypes))
+
+	for typ := range uniqueTypes {
+		types = append(types, GitLabEventType(typ))
+	}
+	sort.Strings(types)
+
+	return types
+}
+
+// eventTypeForWebhook returns the type of event emitted by a given GitLab
+// webhook.
+func eventTypeForWebhook(webhookName string) string {
+	eventTypesByWebhook := map[string]string{
+		GitLabWebhookConfidentialIssues: GitLabEventTypeIssue,
+		GitLabWebhookConfidentialNote:   GitLabEventTypeNote,
+		GitLabWebhookDeployment:         GitLabEventTypeDeployment,
+		GitLabWebhookIssues:             GitLabEventTypeIssue,
+		GitLabWebhookJob:                GitLabEventTypeBuild,
+		GitLabWebhookMergeRequests:      GitLabEventTypeMergeRequest,
+		GitLabWebhookNote:               GitLabEventTypeNote,
+		GitLabWebhookPipeline:           GitLabEventTypePipeline,
+		GitLabWebhookPush:               GitLabEventTypePush,
+		GitLabWebhookTagPush:            GitLabEventTypeTagPush,
+		GitLabWebhookWikiPage:           GitLabEventTypeWikiPage,
+	}
+
+	return eventTypesByWebhook[webhookName]
+}

--- a/pkg/apis/sources/v1alpha1/gitlabsource_lifecyle.go
+++ b/pkg/apis/sources/v1alpha1/gitlabsource_lifecyle.go
@@ -99,3 +99,9 @@ func eventTypeForWebhook(webhookName string) string {
 
 	return eventTypesByWebhook[webhookName]
 }
+
+// AsEventSource returns a unique reference to the source suitable for use as a
+// CloudEvent source attribute.
+func (s *GitLabSource) AsEventSource() string {
+	return s.Spec.ProjectUrl
+}

--- a/pkg/apis/sources/v1alpha1/gitlabsource_lifecyle_test.go
+++ b/pkg/apis/sources/v1alpha1/gitlabsource_lifecyle_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventTypes(t *testing.T) {
+	definedWebhooks := []string{
+		GitLabWebhookPush,               // "push"
+		GitLabWebhookMergeRequests,      // "merge_request"
+		GitLabWebhookPush,               // repeat a previous item
+		GitLabWebhookConfidentialIssues, // / pick webhooks that emit...
+		GitLabWebhookIssues,             // \ ...the same event type ("issue")
+	}
+
+	expectTypes := []string{
+		"dev.knative.sources.gitlab.issue",
+		"dev.knative.sources.gitlab.merge_request",
+		"dev.knative.sources.gitlab.push",
+	}
+
+	testSrc := &GitLabSource{
+		Spec: GitLabSourceSpec{
+			EventTypes: definedWebhooks,
+		},
+	}
+
+	assert.Equal(t, expectTypes, testSrc.EventTypes())
+}

--- a/pkg/apis/sources/v1alpha1/gitlabsource_lifecyle_test.go
+++ b/pkg/apis/sources/v1alpha1/gitlabsource_lifecyle_test.go
@@ -31,7 +31,7 @@ func TestEventTypes(t *testing.T) {
 		GitLabWebhookIssues,             // \ ...the same event type ("issue")
 	}
 
-	expectTypes := []string{
+	expectTypes := []string{ // sorted
 		"dev.knative.sources.gitlab.issue",
 		"dev.knative.sources.gitlab.merge_request",
 		"dev.knative.sources.gitlab.push",

--- a/pkg/apis/sources/v1alpha1/gitlabsource_types.go
+++ b/pkg/apis/sources/v1alpha1/gitlabsource_types.go
@@ -54,11 +54,9 @@ type GitLabSourceSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	ProjectUrl string `json:"projectUrl"`
 
-	// EventType is the type of event to receive from GitLab. These
-	// correspond to supported events to the add project hook
+	// List of webhooks to enable on the selected GitLab project.
+	// Those correspond to the attributes enumerated at
 	// https://docs.gitlab.com/ee/api/projects.html#add-project-hook
-	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:Enum=push_events,push_events_branch_filter,issues_events,confidential_issues_events,merge_requests_events,tag_push_events,note_events,job_events,pipeline_events,wiki_page_events
 	EventTypes []string `json:"eventTypes"`
 
 	// AccessToken is the Kubernetes secret containing the GitLab

--- a/pkg/reconciler/source/gitlabsource.go
+++ b/pkg/reconciler/source/gitlabsource.go
@@ -22,31 +22,24 @@ import (
 	"net/url"
 	"strings"
 
-	//k8s.io imports
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+
 	"knative.dev/eventing/pkg/reconciler/source"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
-
-	//knative.dev/serving imports
-
+	"knative.dev/pkg/reconciler"
+	"knative.dev/pkg/resolver"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingclientset "knative.dev/serving/pkg/client/clientset/versioned"
 	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
 
-	//knative.dev/eventing-gitlab imports
 	sourcesv1alpha1 "knative.dev/eventing-gitlab/pkg/apis/sources/v1alpha1"
 	clientset "knative.dev/eventing-gitlab/pkg/client/clientset/versioned"
 	listers "knative.dev/eventing-gitlab/pkg/client/listers/sources/v1alpha1"
-
-	//knative.dev/pkg imports
-
-	"knative.dev/pkg/reconciler"
-	"knative.dev/pkg/resolver"
 )
 
 // Reconciler reconciles a GitLabSource object
@@ -72,6 +65,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *sourcesv1alpha1.
 	source.Status.InitializeConditions()
 	source.Status.ObservedGeneration = source.Generation
 
+	source.Status.CloudEventAttributes = CreateCloudEventAttributes(source.AsEventSource(), source.EventTypes())
+
 	projectName, err := getProjectName(source.Spec.ProjectUrl)
 	if err != nil {
 		return fmt.Errorf("Failed to process project url to get the project name: " + err.Error())
@@ -83,24 +78,28 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *sourcesv1alpha1.
 
 	for _, event := range source.Spec.EventTypes {
 		switch event {
-		case "push_events":
-			hookOptions.PushEvents = true
-		case "issues_events":
-			hookOptions.IssuesEvents = true
-		case "confidential_issues_events":
+		case sourcesv1alpha1.GitLabWebhookConfidentialIssues:
 			hookOptions.ConfidentialIssuesEvents = true
-		case "merge_requests_events":
-			hookOptions.MergeRequestsEvents = true
-		case "tag_push_events":
-			hookOptions.TagPushEvents = true
-		case "pipeline_events":
-			hookOptions.PipelineEvents = true
-		case "wiki_page_events":
-			hookOptions.WikiPageEvents = true
-		case "job_events":
+		case sourcesv1alpha1.GitLabWebhookConfidentialNote:
+			hookOptions.ConfidentialNoteEvents = true
+		case sourcesv1alpha1.GitLabWebhookDeployment:
+			hookOptions.DeploymentEvents = true
+		case sourcesv1alpha1.GitLabWebhookIssues:
+			hookOptions.IssuesEvents = true
+		case sourcesv1alpha1.GitLabWebhookJob:
 			hookOptions.JobEvents = true
-		case "note_events":
+		case sourcesv1alpha1.GitLabWebhookMergeRequests:
+			hookOptions.MergeRequestsEvents = true
+		case sourcesv1alpha1.GitLabWebhookNote:
 			hookOptions.NoteEvents = true
+		case sourcesv1alpha1.GitLabWebhookPipeline:
+			hookOptions.PipelineEvents = true
+		case sourcesv1alpha1.GitLabWebhookPush:
+			hookOptions.PushEvents = true
+		case sourcesv1alpha1.GitLabWebhookTagPush:
+			hookOptions.TagPushEvents = true
+		case sourcesv1alpha1.GitLabWebhookWikiPage:
+			hookOptions.WikiPageEvents = true
 		}
 	}
 	hookOptions.accessToken, err = r.secretFrom(ctx, source.Namespace, source.Spec.AccessToken.SecretKeyRef)
@@ -304,4 +303,19 @@ func (r *Reconciler) getOwnedKnativeService(ctx context.Context, source *sources
 	}
 
 	return nil, apierrors.NewNotFound(servingv1.Resource("services"), "")
+}
+
+// CreateCloudEventAttributes returns CloudEvent attributes for the event types
+// supported by the source.
+func CreateCloudEventAttributes(source string, eventTypes []string) []duckv1.CloudEventAttributes {
+	ceAttributes := make([]duckv1.CloudEventAttributes, len(eventTypes))
+
+	for i, typ := range eventTypes {
+		ceAttributes[i] = duckv1.CloudEventAttributes{
+			Type:   typ,
+			Source: source,
+		}
+	}
+
+	return ceAttributes
 }

--- a/pkg/reconciler/source/gitlabsource.go
+++ b/pkg/reconciler/source/gitlabsource.go
@@ -246,6 +246,9 @@ func (r *Reconciler) generateKnativeServiceObject(source *sourcesv1alpha1.GitLab
 				SecretKeyRef: source.Spec.SecretToken.SecretKeyRef,
 			},
 		}, {
+			Name:  "GITLAB_EVENT_SOURCE",
+			Value: source.AsEventSource(),
+		}, {
 			Name:  "K_SINK",
 			Value: source.Status.SinkURI.String(),
 		}, {
@@ -259,6 +262,7 @@ func (r *Reconciler) generateKnativeServiceObject(source *sourcesv1alpha1.GitLab
 			Value: "9092",
 		}},
 		r.configs.ToEnvVars()...)
+
 	return &servingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", source.Name),

--- a/pkg/reconciler/source/webhook_client.go
+++ b/pkg/reconciler/source/webhook_client.go
@@ -25,21 +25,24 @@ import (
 )
 
 type projectHookOptions struct {
-	accessToken              string
-	secretToken              string
-	project                  string
-	id                       string
-	url                      string
-	PushEvents               bool
-	IssuesEvents             bool
+	accessToken           string
+	secretToken           string
+	project               string
+	id                    string
+	url                   string
+	EnableSSLVerification bool
+
 	ConfidentialIssuesEvents bool
-	MergeRequestsEvents      bool
-	TagPushEvents            bool
-	NoteEvents               bool
+	ConfidentialNoteEvents   bool
+	DeploymentEvents         bool
+	IssuesEvents             bool
 	JobEvents                bool
+	MergeRequestsEvents      bool
+	NoteEvents               bool
 	PipelineEvents           bool
+	PushEvents               bool
+	TagPushEvents            bool
 	WikiPageEvents           bool
-	EnableSSLVerification    bool
 }
 
 type gitlabHookClient struct{}
@@ -74,18 +77,22 @@ func (client gitlabHookClient) Create(baseURL string, options *projectHookOption
 	}
 
 	hookOptions := gitlab.AddProjectHookOptions{
-		URL:                      &options.url,
-		PushEvents:               &options.PushEvents,
-		IssuesEvents:             &options.IssuesEvents,
+		Token:                 &options.secretToken,
+		URL:                   &options.url,
+		EnableSSLVerification: &options.EnableSSLVerification,
+
 		ConfidentialIssuesEvents: &options.ConfidentialIssuesEvents,
-		MergeRequestsEvents:      &options.MergeRequestsEvents,
-		TagPushEvents:            &options.TagPushEvents,
-		NoteEvents:               &options.NoteEvents,
+		ConfidentialNoteEvents:   &options.ConfidentialNoteEvents,
+		IssuesEvents:             &options.IssuesEvents,
 		JobEvents:                &options.JobEvents,
+		MergeRequestsEvents:      &options.MergeRequestsEvents,
+		NoteEvents:               &options.NoteEvents,
 		PipelineEvents:           &options.PipelineEvents,
+		PushEvents:               &options.PushEvents,
+		TagPushEvents:            &options.TagPushEvents,
 		WikiPageEvents:           &options.WikiPageEvents,
-		Token:                    &options.secretToken,
-		EnableSSLVerification:    &options.EnableSSLVerification,
+		// NOTE(antoineco): not supported in this version of xanzy/go-gitlab
+		//DeploymentEvents: &options.DeploymentEvents,
 	}
 
 	hook, _, err := glClient.Projects.AddProjectHook(options.project, &hookOptions, nil)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -163,7 +163,6 @@ github.com/google/mako/internal/quickstore_microservice/proto/quickstore_go_prot
 github.com/google/mako/proto/quickstore/quickstore_go_proto
 github.com/google/mako/spec/proto/mako_go_proto
 # github.com/google/uuid v1.1.2
-## explicit
 github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2


### PR DESCRIPTION
Fixes #20 

## Proposed Changes

- The name of event types is now sanitized and well documented via constants (see `gitlab_lifecycle.go` + CRD manifest)
- The events' source is always set to the configured project (repo) URL, instead of guessing it from the payload.
- Because both of the above are now homogeneous across the reconciler and adapter, we now populate the source's CloudEventAttributes:

    ```yaml
    status:
      ceAttributes:
      - source: https://gitlab.com/antoineco/test
        type: dev.knative.sources.gitlab.issue
      - source: https://gitlab.com/antoineco/test
        type: dev.knative.sources.gitlab.push
    ```

**Release Note**

```release-note
- 🐛 Sanitize the type attribute of emitted CloudEvents so it doesn't contain spaces and capital letters.
- 🎁 Declare event types emitted by a GitLabSource instance so they are propagated as Knative EventTypes.
- 🧽 Ensure the source attribute of emitted CloudEvents is stable and predictable.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
