### PR TITLE
Set POD_NAME env var for logger injection

### DIFF
--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -63,10 +63,10 @@ spec:
           value: knative.dev/sources
         - name: GL_RA_IMAGE
           value: ko://knative.dev/eventing-gitlab/cmd/receive_adapter
-        - name: POD_NAMESPACE
+        - name: POD_NAME
           valueFrom:
             fieldRef:
-              fieldPath: metadata.namespace
+              fieldPath: metadata.name
         image: ko://knative.dev/eventing-gitlab/cmd/controller
         resources:
           limits:

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -76,6 +76,10 @@ spec:
             value: knative.dev/eventing
           - name: WEBHOOK_NAME
             value: gitlab-webhook
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         ports:
           - containerPort: 9090
             name: metrics


### PR DESCRIPTION
Fixes #5

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Inject POD_NAME env var so the Pod name propagates to the logger (https://github.com/knative/pkg/pull/1714)
- Remove unused POD_NAMESPACE env var

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🧽 Propagate the controller's and webhook's Pod names to the logger
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
