### PR TITLE
[release-0.18] Set proper type and source attributes on emitted CloudEvents

### DIFF
--- a/config/300-gitlabsource.yaml
+++ b/config/300-gitlabsource.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -23,19 +22,46 @@ metadata:
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
   annotations:
-    # TODO add schemas and descriptions
+    # Webhook event types as documented at https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#events.
+    # NOTE(antoineco): GitLab doesn't currently provide schemas for those events (gitlab-org/gitlab#208924)
     registry.knative.dev/eventTypes: |
       [
-        { "type": "dev.knative.sources.gitlabsource.push_events" },
-        { "type": "dev.knative.sources.gitlabsource.push_events_branch_filter" },
-        { "type": "dev.knative.sources.gitlabsource.issues_events" },
-        { "type": "dev.knative.sources.gitlabsource.confidential_issues_events" },
-        { "type": "dev.knative.sources.gitlabsource.merge_requests_events" },
-        { "type": "dev.knative.sources.gitlabsource.tag_push_events" },
-        { "type": "dev.knative.sources.gitlabsource.note_events" },
-        { "type": "dev.knative.sources.gitlabsource.job_events" },
-        { "type": "dev.knative.sources.gitlabsource.pipeline_events" },
-        { "type": "dev.knative.sources.gitlabsource.wiki_page_events" }
+        {
+          "type": "dev.knative.sources.gitlab.build",
+          "description": "Triggered on status change of a job."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.deployment",
+          "description": "Triggered when a deployment starts, succeeds, fails, or is cancelled."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.issue",
+          "description": "Triggered when a new issue is created or an existing issue was updated/closed/reopened."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.merge_request",
+          "description": "Triggered when a merge request is created/updated/merged/closed or a commit is added in the source branch."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.note",
+          "description": "Triggered when a new comment is made on commits, merge requests, issues, and code snippets."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.pipeline",
+          "description": "Triggered on status change of Pipeline."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.push",
+          "description": "Triggered when you push to the repository except when pushing tags."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.tag_push",
+          "description": "Triggered when you create (or delete) tags to the repository."
+        },
+        {
+          "type": "dev.knative.sources.gitlab.wiki_page",
+          "description": "Triggered when a wiki page is created, updated or deleted."
+        }
       ]
 spec:
   group: sources.knative.dev
@@ -96,8 +122,8 @@ spec:
                         a valid secret key.
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      # TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                     optional:
                       description: Specify whether the Secret or its key must be defined
@@ -107,19 +133,21 @@ spec:
                   type: object
               type: object
             eventTypes:
-              description: EventType is the type of event to receive from Gitlab.
-                These correspond to supported events to the add project hook https://docs.gitlab.com/ee/api/projects.html#add-project-hook
+              description: List of webhooks to enable on the selected GitLab
+                project. Those correspond to the attributes enumerated at
+                https://docs.gitlab.com/ee/api/projects.html#add-project-hook
               items:
                 enum:
-                - push_events
-                - push_events_branch_filter
-                - issues_events
                 - confidential_issues_events
-                - merge_requests_events
-                - tag_push_events
-                - note_events
+                - confidential_note_events
+                - deployment_events
+                - issues_events
                 - job_events
+                - merge_requests_events
+                - note_events
                 - pipeline_events
+                - push_events
+                - tag_push_events
                 - wiki_page_events
                 type: string
               minItems: 1

--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -68,7 +68,6 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: ko://knative.dev/eventing-gitlab/cmd/controller
-        imagePullPolicy: Always
         resources:
           limits:
             cpu: 100m

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,8 @@ go 1.14
 require (
 	github.com/cloudevents/sdk-go/v2 v2.2.0
 	github.com/google/go-cmp v0.5.2
-	github.com/google/uuid v1.1.1
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/stretchr/testify v1.6.0 // indirect
+	github.com/stretchr/testify v1.6.0
 	github.com/xanzy/go-gitlab v0.39.0
 	go.opencensus.io v0.22.5-0.20200716030834-3456e1d174b2 // indirect
 	go.uber.org/zap v1.15.0

--- a/pkg/adapter/receive_adapter_test.go
+++ b/pkg/adapter/receive_adapter_test.go
@@ -20,15 +20,20 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
+
 	"gopkg.in/go-playground/webhooks.v5/gitlab"
+
+	"knative.dev/eventing-gitlab/pkg/apis/sources/v1alpha1"
 	"knative.dev/eventing/pkg/adapter/v2"
 	adaptertest "knative.dev/eventing/pkg/adapter/v2/test"
 	"knative.dev/pkg/logging"
@@ -36,8 +41,8 @@ import (
 )
 
 const (
-	testSource  = "https://foo/bar/baz"
 	secretToken = "gitlabsecret"
+	projectURL  = "http://gitlab.example.com/myuser/myproject"
 )
 
 // testCase holds a single row of our GitLabSource table tests
@@ -45,8 +50,8 @@ type testCase struct {
 	// name is a descriptive name for this test suitable as a first argument to t.Run()
 	name string
 
-	// wantRsp contains the pattern to match the returned server response
-	wantResp string
+	// wantErr is the expected error returned in the server's response
+	wantErr error
 
 	// which status code server should return
 	statusCode int
@@ -60,95 +65,59 @@ type testCase struct {
 
 var testCases = []testCase{
 	{
-		name: "valid comment",
-		payload: func() interface{} {
-			pl := gitlab.CommentEventPayload{}
-			pl.ObjectAttributes.URL = testSource
-			return pl
-		}(),
+		name:       "valid comment",
+		payload:    gitlab.CommentEventPayload{},
 		eventType:  gitlab.CommentEvents,
 		statusCode: 202,
 	}, {
-		name: "valid issues",
-		payload: func() interface{} {
-			pl := gitlab.IssueEventPayload{}
-			pl.ObjectAttributes.URL = testSource
-			return pl
-		}(),
+		name:       "valid issues",
+		payload:    gitlab.IssueEventPayload{},
 		eventType:  gitlab.IssuesEvents,
 		statusCode: 202,
 	}, {
-		name: "valid push",
-		payload: func() interface{} {
-			pl := gitlab.PushEventPayload{}
-			pl.Project.HTTPURL = testSource
-			return pl
-		}(),
+		name:       "valid push",
+		payload:    gitlab.PushEventPayload{},
 		eventType:  gitlab.PushEvents,
 		statusCode: 202,
 	}, {
-		name: "valid tag event",
-		payload: func() interface{} {
-			pl := gitlab.TagEventPayload{}
-			pl.Project.HTTPURL = testSource
-			return pl
-		}(),
+		name:       "valid tag event",
+		payload:    gitlab.TagEventPayload{},
 		eventType:  gitlab.TagEvents,
 		statusCode: 202,
 	}, {
-		name: "valid confidential issue event",
-		payload: func() interface{} {
-			pl := gitlab.ConfidentialIssueEventPayload{}
-			pl.ObjectAttributes.URL = testSource
-			return pl
-		}(),
+		name:       "valid confidential issue event",
+		payload:    gitlab.ConfidentialIssueEventPayload{},
 		eventType:  gitlab.ConfidentialIssuesEvents,
 		statusCode: 202,
 	}, {
-		name: "valid merge request event",
-		payload: func() interface{} {
-			pl := gitlab.MergeRequestEventPayload{}
-			pl.ObjectAttributes.URL = testSource
-			return pl
-		}(),
+		name:       "valid merge request event",
+		payload:    gitlab.MergeRequestEventPayload{},
 		eventType:  gitlab.MergeRequestEvents,
 		statusCode: 202,
 	}, {
-		name: "valid wiki page event",
-		payload: func() interface{} {
-			pl := gitlab.WikiPageEventPayload{}
-			pl.ObjectAttributes.URL = testSource
-			return pl
-		}(),
+		name:       "valid wiki page event",
+		payload:    gitlab.WikiPageEventPayload{},
 		eventType:  gitlab.WikiPageEvents,
 		statusCode: 202,
 	}, {
-		name: "valid pipeline event",
-		payload: func() interface{} {
-			pl := gitlab.PipelineEventPayload{}
-			pl.Project.HTTPURL = testSource
-			return pl
-		}(),
+		name:       "valid pipeline event",
+		payload:    gitlab.PipelineEventPayload{},
 		eventType:  gitlab.PipelineEvents,
 		statusCode: 202,
 	}, {
-		name: "valid build event",
-		payload: func() interface{} {
-			pl := gitlab.BuildEventPayload{}
-			pl.Repository.URL = testSource
-			return pl
-		}(),
+		name:       "valid build event",
+		payload:    gitlab.BuildEventPayload{},
 		eventType:  gitlab.BuildEvents,
 		statusCode: 202,
 	}, {
 		name:       "invalid nil payload",
 		payload:    nil,
-		eventType:  gitlab.Event("invalid"),
-		wantResp:   "event not registered",
-		statusCode: 200,
+		eventType:  gitlab.Event("Invalid Hook"),
+		wantErr:    gitlab.ErrEventNotFound,
+		statusCode: 400,
 	}, {
 		name:       "invalid empty eventType",
-		wantResp:   gitlab.ErrMissingGitLabEventHeader.Error(),
+		wantErr:    gitlab.ErrMissingGitLabEventHeader,
 		statusCode: 400,
 	},
 }
@@ -192,8 +161,8 @@ func newTestAdapter(t *testing.T, ce cloudevents.Client) *gitLabReceiveAdapter {
 		EnvConfig: adapter.EnvConfig{
 			Namespace: "default",
 		},
-		EnvSecret: secretToken,
-		Port:      "12342",
+		EnvSecret:   secretToken,
+		EventSource: projectURL,
 	}
 	ctx, _ := pkgtesting.SetupFakeContext(t)
 	logger := zap.NewExample().Sugar()
@@ -205,8 +174,8 @@ func newTestAdapter(t *testing.T, ce cloudevents.Client) *gitLabReceiveAdapter {
 // runner returns a testing func that can be passed to t.Run.
 func (tc *testCase) runner(t *testing.T, url string, ceClient *adaptertest.TestCloudEventsClient) func(*testing.T) {
 	return func(t *testing.T) {
-		body, _ := json.Marshal(tc.payload)
-		req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+		reqBody, _ := json.Marshal(tc.payload)
+		req, err := http.NewRequest("POST", url, bytes.NewReader(reqBody))
 		if err != nil {
 			t.Error(err)
 		}
@@ -222,41 +191,70 @@ func (tc *testCase) runner(t *testing.T, url string, ceClient *adaptertest.TestC
 			t.Errorf("Unexpected status code: %s", resp.Status)
 		}
 
-		data, err := ioutil.ReadAll(resp.Body)
+		respBody, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Error(err)
 		}
 
-		if err := tc.validateResponse(t, string(data)); err != nil {
-			t.Error(err)
-		}
-		if err := tc.validateAcceptedPayload(t, ceClient); err != nil {
-			t.Error(err)
-		}
+		tc.validateResponse(t, string(respBody))
+
+		tc.validateAcceptedPayload(t, ceClient, tc.statusCode)
 	}
 }
 
-func (tc *testCase) validateAcceptedPayload(t *testing.T, ce *adaptertest.TestCloudEventsClient) error {
-	if len(ce.Sent()) != 1 {
-		return nil
-	}
+func (tc *testCase) validateAcceptedPayload(t *testing.T, ce *adaptertest.TestCloudEventsClient, httpCode int) {
+	sentEvents := ce.Sent()
 
-	got := ce.Sent()[0].Data()
-
-	data, err := json.Marshal(tc.payload)
-	if err != nil {
-		return fmt.Errorf("Could not marshal sent payload: %v", err)
+	if httpCode/100 != 2 {
+		require.Len(t, sentEvents, 0, "Event sent despite the non-success HTTP code")
+		return
 	}
+	require.Len(t, sentEvents, 1, "More than 1 event was sent in reaction to the webhooks's message")
 
-	if string(got) != string(data) {
-		return fmt.Errorf("Expected %q event to be sent, got %q", data, string(got))
-	}
-	return nil
+	expectCEType := v1alpha1.GitLabEventType(gitlabEventHeaderToEventType(string(tc.eventType)))
+	expectCESource := projectURL
+	expectCEExt := string(tc.eventType)
+	expectData, err := json.Marshal(tc.payload)
+	require.NoError(t, err, "Unable to serialize GitLab payload")
+
+	sentEvent := ce.Sent()[0]
+
+	assert.Equal(t, expectCEType, sentEvent.Type(),
+		"CloudEvent type doesn't match the webhook's event header")
+	assert.Equal(t, expectCESource, sentEvent.Source(),
+		"CloudEvent source doesn't match the project's URL")
+	assert.Equal(t, expectCEExt, sentEvent.Extensions()[glHeaderEventCEAttr],
+		"CloudEvent extension doesn't match the match the webhook's event header")
+	assert.Equal(t, expectData, sentEvent.Data(),
+		"CloudEvent data differs from original payload")
 }
 
-func (tc *testCase) validateResponse(t *testing.T, message string) error {
-	if tc.wantResp != "" && tc.wantResp != message {
-		return fmt.Errorf("Expected %q response, got %q", tc.wantResp, message)
+func (tc *testCase) validateResponse(t *testing.T, body string) {
+	if tc.wantErr != nil {
+		assert.EqualError(t, tc.wantErr, body)
+		return
 	}
-	return nil
+	assert.Empty(t, body)
+}
+
+func TestGitLabEventHeaderToEventType(t *testing.T) {
+	testCases := map[string]struct {
+		input  string
+		expect string
+	}{
+		"bad format": {
+			input:  "Missing The Suffix",
+			expect: "",
+		},
+		"good format": {
+			input:  "Legit Event Type Hook",
+			expect: "legit_event_type",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(*testing.T) {
+			assert.Equal(t, tc.expect, gitlabEventHeaderToEventType(tc.input))
+		})
+	}
 }

--- a/pkg/apis/sources/v1alpha1/gitlabsource_lifecyle.go
+++ b/pkg/apis/sources/v1alpha1/gitlabsource_lifecyle.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import "sort"
+
+// String prepended to GitLab event types to make them fully-qualified.
+const eventPrefixGitLab = "dev.knative.sources.gitlab."
+
+// Types of events emitted by a GitLabSource.
+// The chosen format and case matches the "object_kind" attribute contained in
+// payloads sent by GitLab's webhooks.
+// https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#events
+const (
+	GitLabEventTypeBuild        = "build"
+	GitLabEventTypeDeployment   = "deployment"
+	GitLabEventTypeIssue        = "issue"
+	GitLabEventTypeMergeRequest = "merge_request"
+	GitLabEventTypeNote         = "note"
+	GitLabEventTypePipeline     = "pipeline"
+	GitLabEventTypePush         = "push"
+	GitLabEventTypeTagPush      = "tag_push"
+	GitLabEventTypeWikiPage     = "wiki_page"
+)
+
+// Types of webhooks that can be enabled on a GitLab project.
+// https://docs.gitlab.com/ee/api/projects.html#add-project-hook
+const (
+	GitLabWebhookConfidentialIssues = "confidential_issues_events"
+	GitLabWebhookConfidentialNote   = "confidential_note_events"
+	GitLabWebhookDeployment         = "deployment_events"
+	GitLabWebhookIssues             = "issues_events"
+	GitLabWebhookJob                = "job_events"
+	GitLabWebhookMergeRequests      = "merge_requests_events"
+	GitLabWebhookNote               = "note_events"
+	GitLabWebhookPipeline           = "pipeline_events"
+	GitLabWebhookPush               = "push_events"
+	GitLabWebhookTagPush            = "tag_push_events"
+	GitLabWebhookWikiPage           = "wiki_page_events"
+)
+
+// GitLabEventType returns a GitLab event type in a format suitable for usage
+// as a CloudEvent type attribute.
+func GitLabEventType(eventType string) string {
+	return eventPrefixGitLab + eventType
+}
+
+// EventTypes returns the types of events emitted by the source, sorted in
+// increasing lexical order.
+func (s *GitLabSource) EventTypes() []string {
+	// Some webhooks emit the same event type, so we use a map as an
+	// intermediate store to avoid duplicates in the returned slice.
+	uniqueTypes := make(map[string]struct{}, len(s.Spec.EventTypes))
+
+	for _, hook := range s.Spec.EventTypes {
+		uniqueTypes[eventTypeForWebhook(hook)] = struct{}{}
+	}
+
+	types := make([]string, 0, len(uniqueTypes))
+
+	for typ := range uniqueTypes {
+		types = append(types, GitLabEventType(typ))
+	}
+	sort.Strings(types)
+
+	return types
+}
+
+// eventTypeForWebhook returns the type of event emitted by a given GitLab
+// webhook.
+func eventTypeForWebhook(webhookName string) string {
+	eventTypesByWebhook := map[string]string{
+		GitLabWebhookConfidentialIssues: GitLabEventTypeIssue,
+		GitLabWebhookConfidentialNote:   GitLabEventTypeNote,
+		GitLabWebhookDeployment:         GitLabEventTypeDeployment,
+		GitLabWebhookIssues:             GitLabEventTypeIssue,
+		GitLabWebhookJob:                GitLabEventTypeBuild,
+		GitLabWebhookMergeRequests:      GitLabEventTypeMergeRequest,
+		GitLabWebhookNote:               GitLabEventTypeNote,
+		GitLabWebhookPipeline:           GitLabEventTypePipeline,
+		GitLabWebhookPush:               GitLabEventTypePush,
+		GitLabWebhookTagPush:            GitLabEventTypeTagPush,
+		GitLabWebhookWikiPage:           GitLabEventTypeWikiPage,
+	}
+
+	return eventTypesByWebhook[webhookName]
+}
+
+// AsEventSource returns a unique reference to the source suitable for use as a
+// CloudEvent source attribute.
+func (s *GitLabSource) AsEventSource() string {
+	return s.Spec.ProjectUrl
+}

--- a/pkg/apis/sources/v1alpha1/gitlabsource_lifecyle_test.go
+++ b/pkg/apis/sources/v1alpha1/gitlabsource_lifecyle_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventTypes(t *testing.T) {
+	definedWebhooks := []string{
+		GitLabWebhookPush,               // "push"
+		GitLabWebhookMergeRequests,      // "merge_request"
+		GitLabWebhookPush,               // repeat a previous item
+		GitLabWebhookConfidentialIssues, // / pick webhooks that emit...
+		GitLabWebhookIssues,             // \ ...the same event type ("issue")
+	}
+
+	expectTypes := []string{ // sorted
+		"dev.knative.sources.gitlab.issue",
+		"dev.knative.sources.gitlab.merge_request",
+		"dev.knative.sources.gitlab.push",
+	}
+
+	testSrc := &GitLabSource{
+		Spec: GitLabSourceSpec{
+			EventTypes: definedWebhooks,
+		},
+	}
+
+	assert.Equal(t, expectTypes, testSrc.EventTypes())
+}

--- a/pkg/apis/sources/v1alpha1/gitlabsource_types.go
+++ b/pkg/apis/sources/v1alpha1/gitlabsource_types.go
@@ -54,11 +54,9 @@ type GitLabSourceSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	ProjectUrl string `json:"projectUrl"`
 
-	// EventType is the type of event to receive from GitLab. These
-	// correspond to supported events to the add project hook
+	// List of webhooks to enable on the selected GitLab project.
+	// Those correspond to the attributes enumerated at
 	// https://docs.gitlab.com/ee/api/projects.html#add-project-hook
-	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:Enum=push_events,push_events_branch_filter,issues_events,confidential_issues_events,merge_requests_events,tag_push_events,note_events,job_events,pipeline_events,wiki_page_events
 	EventTypes []string `json:"eventTypes"`
 
 	// AccessToken is the Kubernetes secret containing the GitLab

--- a/pkg/reconciler/source/webhook_client.go
+++ b/pkg/reconciler/source/webhook_client.go
@@ -25,21 +25,24 @@ import (
 )
 
 type projectHookOptions struct {
-	accessToken              string
-	secretToken              string
-	project                  string
-	id                       string
-	url                      string
-	PushEvents               bool
-	IssuesEvents             bool
+	accessToken           string
+	secretToken           string
+	project               string
+	id                    string
+	url                   string
+	EnableSSLVerification bool
+
 	ConfidentialIssuesEvents bool
-	MergeRequestsEvents      bool
-	TagPushEvents            bool
-	NoteEvents               bool
+	ConfidentialNoteEvents   bool
+	DeploymentEvents         bool
+	IssuesEvents             bool
 	JobEvents                bool
+	MergeRequestsEvents      bool
+	NoteEvents               bool
 	PipelineEvents           bool
+	PushEvents               bool
+	TagPushEvents            bool
 	WikiPageEvents           bool
-	EnableSSLVerification    bool
 }
 
 type gitlabHookClient struct{}
@@ -74,18 +77,22 @@ func (client gitlabHookClient) Create(baseURL string, options *projectHookOption
 	}
 
 	hookOptions := gitlab.AddProjectHookOptions{
-		URL:                      &options.url,
-		PushEvents:               &options.PushEvents,
-		IssuesEvents:             &options.IssuesEvents,
+		Token:                 &options.secretToken,
+		URL:                   &options.url,
+		EnableSSLVerification: &options.EnableSSLVerification,
+
 		ConfidentialIssuesEvents: &options.ConfidentialIssuesEvents,
-		MergeRequestsEvents:      &options.MergeRequestsEvents,
-		TagPushEvents:            &options.TagPushEvents,
-		NoteEvents:               &options.NoteEvents,
+		ConfidentialNoteEvents:   &options.ConfidentialNoteEvents,
+		IssuesEvents:             &options.IssuesEvents,
 		JobEvents:                &options.JobEvents,
+		MergeRequestsEvents:      &options.MergeRequestsEvents,
+		NoteEvents:               &options.NoteEvents,
 		PipelineEvents:           &options.PipelineEvents,
+		PushEvents:               &options.PushEvents,
+		TagPushEvents:            &options.TagPushEvents,
 		WikiPageEvents:           &options.WikiPageEvents,
-		Token:                    &options.secretToken,
-		EnableSSLVerification:    &options.EnableSSLVerification,
+		// NOTE(antoineco): not supported in this version of xanzy/go-gitlab
+		//DeploymentEvents: &options.DeploymentEvents,
 	}
 
 	hook, _, err := glClient.Projects.AddProjectHook(options.project, &hookOptions, nil)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -165,7 +165,6 @@ github.com/google/mako/internal/quickstore_microservice/proto/quickstore_go_prot
 github.com/google/mako/proto/quickstore/quickstore_go_proto
 github.com/google/mako/spec/proto/mako_go_proto
 # github.com/google/uuid v1.1.1
-## explicit
 github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2


### PR DESCRIPTION
Backport of #24 to release-0.18 branch.

---

**Release Note**

```release-note
🐛 Sanitize the type attribute of emitted CloudEvents so it doesn't contain spaces and capital letters.
🎁 Declare event types emitted by a GitLabSource instance so they are propagated as Knative EventTypes.
🧽 Ensure the source attribute of emitted CloudEvents is stable and predictable.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->