### PR TITLE
Fix webhook name in webhook configs

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -123,7 +123,7 @@ func main() {
 	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
 		ServiceName: webhook.NameFromEnv(),
 		Port:        8443,
-		SecretName:  "gitlabsource-webhook-certs",
+		SecretName:  "gitlab-webhook-certs",
 	})
 
 	glbSelector := psbinding.WithSelector(psbinding.ExclusionSelector)

--- a/config/500-webhook-configuration.yaml
+++ b/config/500-webhook-configuration.yaml
@@ -23,7 +23,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: gitlab-source-webhook
+      name: gitlab-webhook
       namespace: knative-sources
   failurePolicy: Fail
   name: defaulting.webhook.gitlab.sources.knative.dev
@@ -39,7 +39,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: gitlab-source-webhook
+      name: gitlab-webhook
       namespace: knative-sources
   failurePolicy: Fail
   name: validation.webhook.gitlab.sources.knative.dev
@@ -57,7 +57,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: gitlab-source-webhook
+      name: gitlab-webhook
       namespace: knative-sources
   failurePolicy: Fail
   name: gitlabbindings.webhook.gitlab.sources.knative.dev

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: gitlabsource-webhook-certs
+  name: gitlab-webhook-certs
   namespace: knative-sources
   labels:
     contrib.eventing.knative.dev/release: devel
@@ -29,7 +29,7 @@ metadata:
   labels:
     contrib.eventing.knative.dev/release: devel
     role: webhook
-  name: gitlab-source-webhook
+  name: gitlab-webhook
   namespace: knative-sources
 spec:
   ports:


### PR DESCRIPTION
Fixes #71 

## Proposed Changes

- Remove `"-source"` from webhook configs, since WEBHOOK_NAME is just `"gitlab-webhook"`
- Rename the webhook Service to match that naming scheme, and be consistent with what's done in other repos (e.g. `eventing-github`).
- Rename the webhook Secret to match that naming scheme, and be consistent with what's done in other repos (e.g. `eventing-github`).

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 Fix name of the webhook Service in webhook configurations (validation, defaulting)
action required: The `gitlab-source-webhook` Service was renamed to `gitlab-webhook` and can safely be deleted after upgrading to the new version.
action required: The `gitlabsource-webhook-certs` Secret was renamed to `gitlab-webhook-certs` and can safely be deleted after upgrading to the new version.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
