### PR TITLE
Fix RBAC permissions for leases (leader election)

### DIFF
--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -90,7 +90,7 @@ rules:
 - apiGroups:
   - coordination.k8s.io
   resourceNames:
-  - gitlab-controller.knative.dev-eventing-contrib-gitlab-pkg-reconciler-source.reconciler.00-of-01
+  - gitlab-controller.knative.dev-eventing-gitlab-pkg-reconciler-source.reconciler.00-of-01
   resources:
   - leases
   verbs:


### PR DESCRIPTION
## Proposed Changes

- Fix the lease name for leader election in the controller's RBAC role

The package was renamed after `knative/eventing-contrib` was split, but, since we explicitly define the name of the lease that we allow the controller to read/update, the name of that lease doesn't match what's in the RBAC config anymore.

The controller logs are full of this error:
`leaderelection.go:320] error retrieving resource lock knative-sources/gitlab-controller.knative.dev-eventing-gitlab-pkg-reconciler-source.reconciler.00-of-01: leases.coordination.k8s.io "gitlab-controller.knative.dev-eventing-gitlab-pkg-reconciler-source.reconciler.00-of-01" is forbidden: User "system:serviceaccount:knative-sources:gitlab-controller-manager" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "knative-sources"`

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 Fix RBAC permissions preventing leader election from working as intended
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
