### PR TITLE
Fix name of lease in clusterrole

### DIFF
--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -90,7 +90,7 @@ rules:
 - apiGroups:
   - coordination.k8s.io
   resourceNames:
-  - gitlab-controller.knative.dev-eventing-contrib-gitlab-pkg-reconciler-source.reconciler.00-of-01
+  - gitlab-controller.knative.dev-eventing-gitlab-pkg-reconciler-source.reconciler.00-of-01
   resources:
   - leases
   verbs:


### PR DESCRIPTION
Fixes broken leader election after installation.

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Update name of lease object in cluster role to match what the controller is trying to update

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

```release-note
- Fix broken deployment due to incorrect leader election authorization
```

