### PR TITLE
Update CRDs to apiextensions.k8s.io/v1

### DIFF
--- a/config/300-gitlabbinding.yaml
+++ b/config/300-gitlabbinding.yaml
@@ -12,35 +12,114 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: gitlabbindings.bindings.knative.dev
   labels:
     contrib.eventing.knative.dev/release: devel
     duck.knative.dev/binding: "true"
     knative.dev/crd-install: "true"
-  name: gitlabbindings.bindings.knative.dev
 spec:
   group: bindings.knative.dev
+  scope: Namespaced
   names:
+    kind: GitLabBinding
+    plural: gitlabbindings
     categories:
     - all
     - knative
     - eventing
     - bindings
-    kind: GitLabBinding
-    plural: gitlabbindings
-  scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: Ready
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-  - name: Reason
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              accessToken:
+                type: object
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      key:
+                        type: string
+                    required:
+                    - name
+                    - key
+              subject:
+                type: object
+                properties:
+                  apiVersion:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  selector:
+                    type: object
+                    properties:
+                      matchLabels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                    required:
+                    - matchLabels
+                oneOf:
+                - required:
+                  - apiVersion
+                  - kind
+                  - name
+                - required:
+                  - apiVersion
+                  - kind
+                  - selector
+          status:
+            type: object
+            properties:
+              observedGeneration:
+                type: integer
+                format: int64
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                      enum: ['True', 'False', Unknown]
+                    severity:
+                      type: string
+                      enum: [Error, Warning, Info]
+                    reason:
+                      type: string
+                    message:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                  required:
+                  - type
+                  - status
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+    - name: Reason
+      type: string
+      jsonPath: .status.conditions[?(@.type=='Ready')].reason
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp

--- a/config/300-gitlabsource.yaml
+++ b/config/300-gitlabsource.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: gitlabsources.sources.knative.dev
@@ -65,213 +65,191 @@ metadata:
       ]
 spec:
   group: sources.knative.dev
+  scope: Namespaced
   names:
     kind: GitLabSource
-    listKind: GitLabSourceList
     plural: gitlabsources
-    singular: gitlabsource
     categories:
-      - all
-      - knative
-      - eventing
-      - sources
-  scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: Ready
-    type: string
-    JSONPath: .status.conditions[?(@.type=='Ready')].status
-  - name: Reason
-    type: string
-    JSONPath: .status.conditions[?(@.type=='Ready')].reason
-  - name: Sink
-    type: string
-    JSONPath: .status.sinkUri
-  - name: Age
-    type: date
-    JSONPath: .metadata.creationTimestamp
-  validation:
-    openAPIV3Schema:
-      description: GitLabSource is the Schema for the gitlabsources API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: GitLabSourceSpec defines the desired state of GitLabSource
-          properties:
-            accessToken:
-              description: AccessToken is the Kubernetes secret containing the GitLab
-                access token
-              properties:
-                secretKeyRef:
-                  description: The Secret key to select from.
-                  properties:
-                    key:
-                      description: The key of the secret to select from.  Must be
-                        a valid secret key.
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      # TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                    optional:
-                      description: Specify whether the Secret or its key must be defined
-                      type: boolean
-                  required:
-                  - key
-                  type: object
-              type: object
-            eventTypes:
-              description: List of webhooks to enable on the selected GitLab
-                project. Those correspond to the attributes enumerated at
-                https://docs.gitlab.com/ee/api/projects.html#add-project-hook
-              items:
-                enum:
-                - confidential_issues_events
-                - confidential_note_events
-                - deployment_events
-                - issues_events
-                - job_events
-                - merge_requests_events
-                - note_events
-                - pipeline_events
-                - push_events
-                - tag_push_events
-                - wiki_page_events
-                type: string
-              minItems: 1
-              type: array
-            projectUrl:
-              description: 'ProjectUrl is the url of the GitLab project for which
-                we are interested to receive events from. Examples:   https://gitlab.com/gitlab-org/gitlab-foss'
-              minLength: 1
-              type: string
-            secretToken:
-              description: SecretToken is the Kubernetes secret containing the GitLab
-                secret token
-              properties:
-                secretKeyRef:
-                  description: The Secret key to select from.
-                  properties:
-                    key:
-                      description: The key of the secret to select from.  Must be
-                        a valid secret key.
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                    optional:
-                      description: Specify whether the Secret or its key must be defined
-                      type: boolean
-                  required:
-                  - key
-                  type: object
-              type: object
-            serviceAccountName:
-              description: ServiceAccountName holds the name of the Kubernetes service
-                account as which the underlying K8s resources should be run. If unspecified
-                this will default to the "default" service account for the namespace
-                in which the GitLabSource exists.
-              type: string
-            sink:
-              description: Sink is a reference to an object that will resolve to a
-                domain name to use as the sink.
-              properties:
-                ref:
-                  description: Ref points to an Addressable.
-                  properties:
-                    apiVersion:
-                      description: API version of the referent.
-                      type: string
-                    kind:
-                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                    namespace:
-                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                        This is optional field, it gets defaulted to the object holding
-                        it if left out.'
-                      type: string
-                  required:
-                  - apiVersion
-                  - kind
-                  - name
-                  type: object
-                uri:
-                  type: string
-                  description: URI can be an absolute URL(non-empty scheme and non-empty
-                    host) pointing to the target or a relative URI. Relative URIs
-                    will be resolved using the base URI retrieved from Ref.
-              type: object
-            sslverify:
-              description: SslVerify if true configure webhook so the ssl verification
-                is done when triggering the hook
-              type: boolean
-          required:
-          - accessToken
-          - eventTypes
-          - projectUrl
-          - secretToken
-          type: object
-        status:
-          description: GitLabSourceStatus defines the observed state of GitLabSource
-          properties:
-            Id:
-              description: ID of the project hook registered with GitLab
-              type: string
-            conditions:
-              items:
-                properties:
-                  lastTransitionTime:
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  severity:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - type
-                - status
-                type: object
-              type: array
-            observedGeneration:
-              description: ObservedGeneration is the 'Generation' of the Service that
-                was last processed by the controller.
-              format: int64
-              type: integer
-            sinkUri:
-              description: SinkURI is the current active sink URI that has been configured
-                for the GitLabSource.
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
+    - all
+    - knative
+    - eventing
+    - sources
   versions:
   - name: v1alpha1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            description: Desired state of the event source.
+            type: object
+            properties:
+              projectUrl:
+                description: URL of the GitLab project to receive events from.
+                type: string
+                format: uri
+              eventTypes:
+                description: List of webhooks to enable on the selected GitLab
+                  project. Those correspond to the attributes enumerated at
+                  https://docs.gitlab.com/ee/api/projects.html#add-project-hook
+                type: array
+                items:
+                  type: string
+                  enum:
+                  - confidential_issues_events
+                  - confidential_note_events
+                  - deployment_events
+                  - issues_events
+                  - job_events
+                  - merge_requests_events
+                  - note_events
+                  - pipeline_events
+                  - push_events
+                  - tag_push_events
+                  - wiki_page_events
+                minItems: 1
+              accessToken:
+                description: Access token for the GitLab API.
+                type: object
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object
+                      containing a GitLab access token.
+                    type: object
+                    properties:
+                      name:
+                        description: The name of the Kubernetes Secret object
+                          which contains the GitLab access token.
+                        type: string
+                      key:
+                        description: The key which contains the GitLab access
+                          token within the Kubernetes Secret object referenced by
+                          name.
+                        type: string
+                    required:
+                    - name
+                    - key
+              secretToken:
+                description: Arbitrary token used to validate requests to
+                  webhooks.
+                type: object
+                properties:
+                  secretKeyRef:
+                    description: A reference to a Kubernetes Secret object
+                      containing the webhook token.
+                    type: object
+                    properties:
+                      name:
+                        description: The name of the Kubernetes Secret object
+                          which contains the webhook token.
+                        type: string
+                      key:
+                        description: The key which contains the webhook token
+                          within the Kubernetes Secret object referenced by name.
+                        type: string
+                    required:
+                    - name
+                    - key
+              sslverify:
+                description: Whether requests to webhooks should be made over
+                  SSL.
+                type: boolean
+              serviceAccountName:
+                description: Service Account the receive adapter Pod should be
+                  using.
+                type: string
+              sink:
+                description: The destination of events received from webhooks.
+                type: object
+                properties:
+                  ref:
+                    description: Reference to an addressable Kubernetes object
+                      to be used as the destination of events.
+                    type: object
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      namespace:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                  uri:
+                    description: URI to use as the destination of events.
+                    type: string
+                    format: uri
+                oneOf:
+                - required: ['ref']
+                - required: ['uri']
+            required:
+            - projectUrl
+            - eventTypes
+            - accessToken
+            - secretToken
+            - sink
+          status:
+            type: object
+            properties:
+              sinkUri:
+                type: string
+                format: uri
+              ceAttributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    source:
+                      type: string
+                  required:
+                  - type
+                  - source
+              observedGeneration:
+                type: integer
+                format: int64
+              conditions:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    status:
+                      type: string
+                      enum: ['True', 'False', Unknown]
+                    severity:
+                      type: string
+                      enum: [Error, Warning, Info]
+                    reason:
+                      type: string
+                    message:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                  required:
+                  - type
+                  - status
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+    - name: Reason
+      type: string
+      jsonPath: .status.conditions[?(@.type=='Ready')].reason
+    - name: Sink
+      type: string
+      jsonPath: .status.sinkUri
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
## Proposed Changes

- Update CRDs to apiextensions.k8s.io/v1. v1beta1 is deprecated.
- Clean up CRD manifests, improve attributes descriptions and validation.