### PR TITLE
Update webhook confs to admissionregistration.k8s.io/v1

### DIFF
--- a/config/500-webhook-configuration.yaml
+++ b/config/500-webhook-configuration.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.gitlab.sources.knative.dev
@@ -25,10 +25,13 @@ webhooks:
     service:
       name: gitlab-source-webhook
       namespace: knative-sources
+  sideEffects: None
   failurePolicy: Fail
   name: defaulting.webhook.gitlab.sources.knative.dev
+
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.gitlab.sources.knative.dev
@@ -41,12 +44,13 @@ webhooks:
     service:
       name: gitlab-source-webhook
       namespace: knative-sources
+  sideEffects: None
   failurePolicy: Fail
   name: validation.webhook.gitlab.sources.knative.dev
 
 ---
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: gitlabbindings.webhook.gitlab.sources.knative.dev
@@ -59,5 +63,6 @@ webhooks:
     service:
       name: gitlab-source-webhook
       namespace: knative-sources
+  sideEffects: None
   failurePolicy: Fail
   name: gitlabbindings.webhook.gitlab.sources.knative.dev


### PR DESCRIPTION

## Proposed Changes

- Update webhook confs to admissionregistration.k8s.io/v1. v1beta1 is deprecated.