### PR TITLE
Set webhook's liveness probe initial delay to 20s

### DIFF
--- a/config/500-webhook-configuration.yaml
+++ b/config/500-webhook-configuration.yaml
@@ -55,7 +55,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: gitlabbindings.webhook.gitlab.sources.knative.dev
   labels:
-    samples.knative.dev/release: devel
+    contrib.eventing.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions:
   - v1beta1

--- a/config/500-webhook.yaml
+++ b/config/500-webhook.yaml
@@ -56,8 +56,6 @@ spec:
       role: gitlab-webhook
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
       labels: *labels
     spec:
       serviceAccountName: gitlab-webhook
@@ -93,4 +91,6 @@ spec:
             httpHeaders:
             - name: k-kubelet-probe
               value: "webhook"
-        livenessProbe: *probe
+        livenessProbe:
+          <<: *probe
+          initialDelaySeconds: 20


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Set webhook's liveness probe initial delay to `20s`, like in the Knative Eventing core.

Without this change, the webhook's certificate may never be created due to the webhook's container being constantly restarted.

```console
$ kubectl -n knative-sources get pod
NAME                               READY   STATUS             RESTARTS   AGE
gitlab-webhook-5484bf5cb4-hdf5m    0/1     CrashLoopBackOff   7          11m
```

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 Prevent a restart loop of the webhook by allowing it more time for generating its initial certificates.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
