### PR TITLE
Add permissions for leases.coordination.k8s.io

### DIFF
--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -87,6 +87,8 @@ rules:
   - leases
   verbs:
   - create
+  - get
+  - update
 - apiGroups:
   - coordination.k8s.io
   resourceNames:

--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -87,12 +87,10 @@ rules:
   - leases
   verbs:
   - create
-  - get
-  - update
 - apiGroups:
   - coordination.k8s.io
   resourceNames:
-  - gitlab-controller.knative.dev-eventing-gitlab-pkg-reconciler-source.reconciler.00-of-01
+  - gitlab-controller.knative.dev.eventing-gitlab.pkg.reconciler.source.reconciler.00-of-01
   resources:
   - leases
   verbs:


### PR DESCRIPTION
Following the installation steps for gitlab source I was getting the following error:
<s>
```
rabbitmq-knative-docs/logs/rabbitmq-source.log:E1207 21:33:08.584935       1 leaderelection.go:320] error retrieving resource lock knative-sources/rabbitmq_controller.knative.dev-eventing-rabbitmq-pkg-reconciler-source.reconciler.00-of-01: leases.coordination.k8s.io "rabbitmq_controller.knative.dev-eventing-rabbitmq-pkg-reconciler-source.reconciler.00-of-01" is forbidden: User "system:serviceaccount:knative-sources:rabbitmq-controller-manager" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "knative-sources"
:knative-sources:gitlab-controller-manager" cannot update resource "leases" in API group "coordination.k8s.io" in the namespace "knative-sources"
E0322 22:32:53.916254       1 leaderelection.go:361] Failed to update lock: leases.coordination.k8s.io "gitlab-controller.knative.dev.eventing-gitlab.pkg.reconciler.source.reconciler.00-of-01" is forbidden: User "system:serviceaccount:knative-sources:gitlab-controller-manager" cannot update resource "leases" in API group "coordination.k8s.io" in the namespace "knative-sources"
```
</s>

I think the following commit addresses this issue.

#### [EDIT]:
Correct Logs:
```
E0322 22:32:53.916254       1 leaderelection.go:361] Failed to update lock: leases.coordination.k8s.io "gitlab-controller.knative.dev.eventing-gitlab.pkg.reconciler.source.reconciler.00-of-01" is forbidden: User "system:serviceaccount:knative-sources:gitlab-controller-manager" cannot update resource "leases" in API group "coordination.k8s.io" in the namespace "knative-sources"
```