### PR TITLE
Remove lease name pinning in ClusterRole

### DIFF
--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -86,15 +86,8 @@ rules:
   resources:
   - leases
   verbs:
-  - create
-- apiGroups:
-  - coordination.k8s.io
-  resourceNames:
-  - gitlab-controller.knative.dev.eventing-gitlab.pkg.reconciler.source.reconciler.00-of-01
-  resources:
-  - leases
-  verbs:
   - get
+  - create
   - update
 
 ---


### PR DESCRIPTION
This name depends on internal mechanics, so depending on it is too fragile.